### PR TITLE
Fix checking whether arguments are same file.

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -965,7 +965,8 @@ compare_files (dir0, name0, dir1, name1, depth)
 
     }
   else if ((same_files = inf[0].desc != -1 && inf[1].desc != -1
-			 && 0 < same_file (&inf[0].stat, &inf[1].stat))
+			 && 0 < same_file (&inf[0].stat, &inf[1].stat)
+			 && same_file_attributes (&inf[0].stat, &inf[1].stat))
 	   && no_diff_means_no_output)
     {
       /* The two named files are actually the same physical file.

--- a/src/system.h
+++ b/src/system.h
@@ -248,6 +248,17 @@ extern int errno;
 #define same_file(s,t) ((s)->st_ino==(t)->st_ino && (s)->st_dev==(t)->st_dev)
 #endif
 
+#ifndef same_file_attributes
+# define same_file_attributes(s, t) \
+   ((s)->st_mode == (t)->st_mode \
+    && (s)->st_nlink == (t)->st_nlink \
+    && (s)->st_uid == (t)->st_uid \
+    && (s)->st_gid == (t)->st_gid \
+    && (s)->st_size == (t)->st_size \
+    && (s)->st_mtime == (t)->st_mtime \
+    && (s)->st_ctime == (t)->st_ctime)
+#endif
+
 /* Place into Q a quoted version of A suitable for `popen' or `system',
    incrementing Q and junking A.
    Do not increment Q by more than 4 * strlen (A) + 2.  */


### PR DESCRIPTION
diff.exeの実行時に，差分を確認したいファイルを引数に渡しても，差分を表示しない問題を修正した。

diff.cにおいて，引数に渡した二つのファイルが同じファイルかどうかをif文で判定している箇所がある。ここの条件が不足しており，内容の違うファイルが誤って同じファイルと認識されてしまっていた。

[GnuWin32 diffutils 2.8.7](http://gnuwin32.sourceforge.net/packages/diffutils.htm]) のソースを参考にして，該当箇所である，diff.cとsystem.hから必要な条件とマクロをそのままコピーペーストして，ファイルの属性も比較対象とした。

これにより，ファイルの判別が行われ，diff.exeが差分を表示するようになった。
