### PR TITLE
Fix error for directory diff.

### DIFF
--- a/msvc/src/dirent.c
+++ b/msvc/src/dirent.c
@@ -105,6 +105,10 @@ struct dirent *readdir(DIR *dir)
             result         = &dir->result;
             result->d_name = dir->info.name;
         }
+        if(errno == ENOENT)
+        {
+          errno = 0;
+        }
     }
     else
     {

--- a/src/dir.c
+++ b/src/dir.c
@@ -91,7 +91,6 @@ dir_sort (dir, dirdata)
 	  data_used += d_size;
 	  nnames++;
 	}
-#ifndef _WIN32
       if (errno)
 	{
 	  int e = errno;
@@ -99,7 +98,6 @@ dir_sort (dir, dirdata)
 	  errno = e;
 	  return -1;
 	}
-#endif
 #if CLOSEDIR_VOID
       closedir (reading);
 #else

--- a/src/dir.c
+++ b/src/dir.c
@@ -91,6 +91,7 @@ dir_sort (dir, dirdata)
 	  data_used += d_size;
 	  nnames++;
 	}
+#ifndef _WIN32
       if (errno)
 	{
 	  int e = errno;
@@ -98,6 +99,7 @@ dir_sort (dir, dirdata)
 	  errno = e;
 	  return -1;
 	}
+#endif
 #if CLOSEDIR_VOID
       closedir (reading);
 #else


### PR DESCRIPTION
ディレクトリの差分を取るときのエラーを解決しました。

今までは以下のように引数にディレクトリを渡すと，エラーがでてディレクトリの差分が取れませんでした。

```
diff.exe src include
```

```
diff.exe: src: No such file or directory
diff.exe: include: No such file or directory
```

エラーの起きている箇所は，diff.cの1000行目付近のdiff_dirs関数。
https://github.com/lamsh/diffutils/blob/msvc/master/src/diff.c#L1011

```
      val = diff_dirs (inf, compare_files, depth);
```

この関数の中をたどると，dir.cのdir_sort関数が失敗していることがわかる。
https://github.com/lamsh/diffutils/blob/msvc/master/src/dir.c#L169

```
  /* Get sorted contents of both dirs.  */
  for (i = 0; i < 2; i++)
    if (dir_sort (&filevec[i], &dirdata[i]) != 0)
      {
    perror_with_name (filevec[i].name);
    val = 2;
      }
```

dir_sort関数の以下のif文に入ってエラーとなっていた。
https://github.com/lamsh/diffutils/blob/msvc/master/src/dir.c#L95

```
      if (errno)
    {
      int e = errno;
      closedir (reading);
      errno = e;
      return -1;
    }
```

このerrnoは直前のwhileで使われているreaddir関数で設定されている。
https://github.com/lamsh/diffutils/blob/msvc/master/src/dir.c#L75

```
      while ((errno = 0, (next = readdir (reading)) !=0))
```

readdir関数が定義されているdirent.cの_findnext関数が失敗して`errno`が設定されていた。
https://github.com/lamsh/diffutils/blob/msvc/master/msvc/src/dirent.c#L103

```
        if(!dir->result.d_name || _findnext(dir->handle, &dir->info) != -1)
```

_findnext関数は[MSDN](https://msdn.microsoft.com/ja-jp/library/6tkkkc1y.aspx)で以下に書かれている通り，エラーになったときにerrnoに値を設定してしまっているのが問題でした。

> 戻り値
> 正常終了した場合は、0 を返します。 それ以外の場合、戻り–1 とエラーの種類を示す値に設定 errno。 有効なエラーコードを次の表に示します。

そこで，`if (errno)`のブロックをマクロで囲んでWindowsでは評価しないようにしました。これでうまく動作するようになりました。再帰的に比較する-rオプションも有効であることも確認しました。
